### PR TITLE
Feature/add job import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,28 @@ env:
     playbook: test-plugins-with-pinning.yml
     prefix: ''
     http_port: 8080
-    
+
   # tests/test-jobs.yml
   - distro: ubuntu1604
     playbook: test-jobs.yml
+    prefix: ''
+    http_port: 8080
+
+  # tests/test-jobs.yml
+  - distro: ubuntu1604
+    playbook: test-jobs-with-home.yml
+    prefix: ''
+    http_port: 8080
+
+  # tests/test-jobs.yml
+  - distro: ubuntu1604
+    playbook: test-jobs-with-plugins-and-home.yml
+    prefix: ''
+    http_port: 8080
+
+  # tests/test-jobs.yml
+  - distro: ubuntu1604
+    playbook: test-jobs-with-plugins.yml
     prefix: ''
     http_port: 8080
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,12 @@ env:
     playbook: test-plugins-with-pinning.yml
     prefix: ''
     http_port: 8080
+    
+  # tests/test-jobs.yml
+  - distro: ubuntu1604
+    playbook: test-jobs.yml
+    prefix: ''
+    http_port: 8080
 
 script:
   # Configure test script so we can run extra tests after playbook is run.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Number of seconds after which a new copy of the update-center.json file is downl
 
 The server connection timeout, in seconds, when installing Jenkins plugins.
 
+    jenkins_jobs: []
+    Example: [{name: 'testing', config: "{{ lookup('file', './test-job.xml') }}"}]
+
+Jenkins jobs to be created automatically during provisioning.
+
     jenkins_version: "1.644"
     jenkins_pkg_url: "http://www.example.com"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 jenkins_plugin_updates_expiration: 86400
 jenkins_plugin_timeout: 30
+jenkins_jobs: []
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 dependencies:
   - geerlingguy.java
+  - FGtatsuro.python-requirements
+  - novafloss.jenkins-api
 
 galaxy_info:
   author: geerlingguy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - geerlingguy.java
-  - FGtatsuro.python-requirements
+  - andrewrothstein.python
   - novafloss.jenkins-api
 
 galaxy_info:

--- a/tasks/jobs.yml
+++ b/tasks/jobs.yml
@@ -24,6 +24,13 @@
     jenkins_admin_token: "{{ admintokenfile['stdout'] | default(jenkins_admin_token) }}"
   no_log: True
 
+# lxml is needed for xml processing
+- name: Install python lxml
+  pip:
+    executable: pip2
+    name: lxml
+    state: latest
+
 - name: Create Jenkins Jobs using password.
   jenkins_job:
     name: "{{ item.name }}"

--- a/tasks/jobs.yml
+++ b/tasks/jobs.yml
@@ -1,0 +1,45 @@
+---
+# jenkins_job module doesn't support password files.
+- name: Get Jenkins admin password from file.
+  slurp:
+    src: "{{ jenkins_admin_password_file }}"
+  register: adminpasswordfile
+  no_log: True
+  when: jenkins_admin_password_file != ""
+
+- name: Set Jenkins admin password fact.
+  set_fact:
+    jenkins_admin_password: "{{ adminpasswordfile['stdout'] | default(jenkins_admin_password) }}"
+  no_log: True
+
+- name: Get Jenkins admin token from file.
+  slurp:
+    src: "{{ jenkins_admin_token_file }}"
+  register: admintokenfile
+  no_log: True
+  when: jenkins_admin_token_file != ""
+
+- name: Set Jenkins admin token fact.
+  set_fact:
+    jenkins_admin_token: "{{ admintokenfile['stdout'] | default(jenkins_admin_token) }}"
+  no_log: True
+
+- name: Create Jenkins Jobs using password.
+  jenkins_job:
+    name: "{{ item.name }}"
+    config: "{{ item.config }}"
+    user: "{{ jenkins_admin_username }}"
+    password: "{{ jenkins_admin_password }}"
+    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}"
+  with_items: "{{ jenkins_jobs }}"
+  when: jenkins_admin_password != ""
+
+- name: Create Jenkins Jobs using token.
+  jenkins_job:
+    name: "{{ item.name }}"
+    config: "{{ item.config }}"
+    user: "{{ jenkins_admin_username }}"
+    token: "{{ jenkins_admin_token }}"
+    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}"
+  with_items: "{{ jenkins_jobs }}"
+  when: jenkins_admin_token != ""

--- a/tasks/jobs.yml
+++ b/tasks/jobs.yml
@@ -24,13 +24,6 @@
     jenkins_admin_token: "{{ admintokenfile['stdout'] | default(jenkins_admin_token) }}"
   no_log: True
 
-# lxml is needed for xml processing
-- name: Install python lxml
-  pip:
-    executable: pip2
-    name: lxml
-    state: latest
-
 - name: Create Jenkins Jobs using password.
   jenkins_job:
     name: "{{ item.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,3 +58,6 @@
 
 # Update Jenkins and install configured plugins.
 - include: plugins.yml
+
+# Create any jobs that are neccessary
+- include: jobs.yml

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -36,7 +36,7 @@
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_password != ""
-  notify: restart jenkins
+  register: jenkins_plugin_password
 
 - name: Install Jenkins plugins using token.
   jenkins_plugin:
@@ -47,4 +47,17 @@
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_token != ""
-  notify: restart jenkins
+  register: jenkins_plugin_token
+
+- name: Immediately restart Jenkins when plugins are installed.
+  service: name=jenkins state=restarted
+  when: jenkins_plugin_password.changed or jenkins_plugin_token.changed
+
+- name: Wait for Jenkins to start up before proceeding.
+  shell: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
+  register: result
+  until: (result.stdout.find("403 Forbidden") != -1) or (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
+  retries: "{{ jenkins_connection_retries }}"
+  delay: "{{ jenkins_connection_delay }}"
+  changed_when: false
+  check_mode: no

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,8 +4,7 @@
     name:
       - curl
       - apt-transport-https
-      - libxml2
-      - libxslt
+      - python-lxml
     state: installed
 
 - name: Add Jenkins apt repository key.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,6 +4,7 @@
     name:
       - curl
       - apt-transport-https
+      - libxml2
     state: installed
 
 - name: Add Jenkins apt repository key.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,6 +5,7 @@
       - curl
       - apt-transport-https
       - libxml2
+      - libxslt
     state: installed
 
 - name: Add Jenkins apt repository key.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,6 +6,7 @@
       - libselinux-python
       - initscripts
       - libxml2
+      - libxslt
     state: installed
 
 - name: Ensure Jenkins repo is installed.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,6 +5,7 @@
       - curl
       - libselinux-python
       - initscripts
+      - libxml2
     state: installed
 
 - name: Ensure Jenkins repo is installed.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,8 +5,7 @@
       - curl
       - libselinux-python
       - initscripts
-      - libxml2
-      - libxslt
+      - python-lxml
     state: installed
 
 - name: Ensure Jenkins repo is installed.

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,2 +1,4 @@
 ---
 - src: geerlingguy.java
+- src: FGtatsuro.python-requirements
+- src: novafloss.jenkins-api

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: geerlingguy.java
-- src: FGtatsuro.python-requirements
+- src: andrewrothstein.python
 - src: novafloss.jenkins-api

--- a/tests/test-http-port.yml
+++ b/tests/test-http-port.yml
@@ -9,6 +9,6 @@
 
   roles:
     - geerlingguy.java
-    - FGtatsuro.python-requirements
+    - andrewrothstein.python
     - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-http-port.yml
+++ b/tests/test-http-port.yml
@@ -9,4 +9,6 @@
 
   roles:
     - geerlingguy.java
+    - FGtatsuro.python-requirements
+    - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-jenkins-version.yml
+++ b/tests/test-jenkins-version.yml
@@ -12,6 +12,6 @@
 
   roles:
     - geerlingguy.java
-    - FGtatsuro.python-requirements
+    - andrewrothstein.python
     - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-jenkins-version.yml
+++ b/tests/test-jenkins-version.yml
@@ -12,4 +12,6 @@
 
   roles:
     - geerlingguy.java
+    - FGtatsuro.python-requirements
+    - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-job.xml
+++ b/tests/test-job.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/test-jobs-with-home.yml
+++ b/tests/test-jobs-with-home.yml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+
+  vars:
+    jenkins_home: /tmp/jenkins
+    jenkins_jobs:
+      - {name: 'testing', config: "{{ lookup('file', './test-job.xml') }}"}
+
+  pre_tasks:
+    - include: java-8.yml
+
+  roles:
+    - geerlingguy.java
+    - andrewrothstein.python
+    - novafloss.jenkins-api
+    - role_under_test

--- a/tests/test-jobs-with-plugins-and-home.yml
+++ b/tests/test-jobs-with-plugins-and-home.yml
@@ -1,0 +1,19 @@
+---
+- hosts: all
+
+  vars:
+    jenkins_home: /tmp/jenkins
+    jenkins_plugins:
+      - greenballs
+    jenkins_plugin_timeout: 120
+    jenkins_jobs:
+      - {name: 'testing', config: "{{ lookup('file', './test-job.xml') }}"}
+
+  pre_tasks:
+    - include: java-8.yml
+
+  roles:
+    - geerlingguy.java
+    - andrewrothstein.python
+    - novafloss.jenkins-api
+    - role_under_test

--- a/tests/test-jobs-with-plugins.yml
+++ b/tests/test-jobs-with-plugins.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+
+  vars:
+    jenkins_plugins:
+      - greenballs
+    jenkins_plugin_timeout: 120
+    jenkins_jobs:
+      - {name: 'testing', config: "{{ lookup('file', './test-job.xml') }}"}
+
+  pre_tasks:
+    - include: java-8.yml
+
+  roles:
+    - geerlingguy.java
+    - andrewrothstein.python
+    - novafloss.jenkins-api
+    - role_under_test

--- a/tests/test-jobs.yml
+++ b/tests/test-jobs.yml
@@ -3,7 +3,7 @@
 
   vars:
     jenkins_jobs:
-      - {name: 'testing', config: '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<project>\n  <description></description>\n  <keepDependencies>false</keepDependencies>\n  <properties/>\n  <scm class="hudson.scm.NullSCM"/>\n  <canRoam>true</canRoam>\n  <disabled>false</disabled>\n  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>\n  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>\n  <triggers/>\n  <concurrentBuild>false</concurrentBuild>\n  <builders/>\n  <publishers/>\n  <buildWrappers/>\n</project>'}
+      - {name: 'testing', config: "{{ lookup('file', './test-job.xml') }}"}
 
   pre_tasks:
     - include: java-8.yml

--- a/tests/test-jobs.yml
+++ b/tests/test-jobs.yml
@@ -3,7 +3,7 @@
 
   vars:
     jenkins_jobs:
-      - {name: 'Deploy - CloudForms to Dev', config: '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<project>\n  <description></description>\n  <keepDependencies>false</keepDependencies>\n  <properties/>\n  <scm class="hudson.scm.NullSCM"/>\n  <canRoam>true</canRoam>\n  <disabled>false</disabled>\n  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>\n  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>\n  <triggers/>\n  <concurrentBuild>false</concurrentBuild>\n  <builders/>\n  <publishers/>\n  <buildWrappers/>\n</project>'}
+      - {name: 'testing', config: '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<project>\n  <description></description>\n  <keepDependencies>false</keepDependencies>\n  <properties/>\n  <scm class="hudson.scm.NullSCM"/>\n  <canRoam>true</canRoam>\n  <disabled>false</disabled>\n  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>\n  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>\n  <triggers/>\n  <concurrentBuild>false</concurrentBuild>\n  <builders/>\n  <publishers/>\n  <buildWrappers/>\n</project>'}
 
   pre_tasks:
     - include: java-8.yml

--- a/tests/test-jobs.yml
+++ b/tests/test-jobs.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+
+  vars:
+    jenkins_jobs:
+      - {name: 'Deploy - CloudForms to Dev', config: '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<project>\n  <description></description>\n  <keepDependencies>false</keepDependencies>\n  <properties/>\n  <scm class="hudson.scm.NullSCM"/>\n  <canRoam>true</canRoam>\n  <disabled>false</disabled>\n  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>\n  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>\n  <triggers/>\n  <concurrentBuild>false</concurrentBuild>\n  <builders/>\n  <publishers/>\n  <buildWrappers/>\n</project>'}
+
+  pre_tasks:
+    - include: java-8.yml
+
+  roles:
+    - geerlingguy.java
+    - andrewrothstein.python
+    - novafloss.jenkins-api
+    - role_under_test

--- a/tests/test-plugins-with-home.yml
+++ b/tests/test-plugins-with-home.yml
@@ -12,6 +12,6 @@
 
   roles:
     - geerlingguy.java
-    - FGtatsuro.python-requirements
+    - andrewrothstein.python
     - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-plugins-with-home.yml
+++ b/tests/test-plugins-with-home.yml
@@ -12,4 +12,6 @@
 
   roles:
     - geerlingguy.java
+    - FGtatsuro.python-requirements
+    - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-plugins-with-pinning.yml
+++ b/tests/test-plugins-with-pinning.yml
@@ -11,4 +11,6 @@
 
   roles:
     - geerlingguy.java
+    - FGtatsuro.python-requirements
+    - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-plugins-with-pinning.yml
+++ b/tests/test-plugins-with-pinning.yml
@@ -11,6 +11,6 @@
 
   roles:
     - geerlingguy.java
-    - FGtatsuro.python-requirements
+    - andrewrothstein.python
     - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-plugins.yml
+++ b/tests/test-plugins.yml
@@ -14,6 +14,6 @@
 
   roles:
     - geerlingguy.java
-    - FGtatsuro.python-requirements
+    - andrewrothstein.python
     - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-plugins.yml
+++ b/tests/test-plugins.yml
@@ -14,4 +14,6 @@
 
   roles:
     - geerlingguy.java
+    - FGtatsuro.python-requirements
+    - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-prefix.yml
+++ b/tests/test-prefix.yml
@@ -9,6 +9,6 @@
 
   roles:
     - geerlingguy.java
-    - FGtatsuro.python-requirements
+    - andrewrothstein.python
     - novafloss.jenkins-api
     - role_under_test

--- a/tests/test-prefix.yml
+++ b/tests/test-prefix.yml
@@ -9,4 +9,6 @@
 
   roles:
     - geerlingguy.java
+    - FGtatsuro.python-requirements
+    - novafloss.jenkins-api
     - role_under_test

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,4 +6,6 @@
 
   roles:
     - geerlingguy.java
+    - FGtatsuro.python-requirements
+    - novafloss.jenkins-api
     - role_under_test

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,6 +6,6 @@
 
   roles:
     - geerlingguy.java
-    - FGtatsuro.python-requirements
+    - andrewrothstein.python
     - novafloss.jenkins-api
     - role_under_test


### PR DESCRIPTION
Added the ability to create jobs during Jenkins provisioning. Added dependencies to needed to install jenkins-python for the job create module in Ansible. To make sure jobs could be created that had plugin dependancies, if plugins are installed the Jenkins service is restarted immediately. Created 4 tests to ensure functionality of the create jobs that can be see here: https://travis-ci.org/EncoreTechnologies/ansible-role-jenkins